### PR TITLE
jquery.fancytree.hotkeys.js: Prevent default behavior on key combination

### DIFF
--- a/3rd-party/extensions/hotkeys/js/jquery.fancytree.hotkeys.js
+++ b/3rd-party/extensions/hotkeys/js/jquery.fancytree.hotkeys.js
@@ -15,9 +15,11 @@
 	var initHotkeys = function(tree, data) {
 		$.each(data, function(event, keys) {
 			$.each(keys, function(key, handler) {
-				$(tree.$container).on(event, null, key, function() {
+				$(tree.$container).on(event, null, key, function(a) {
 					var node = tree.getActiveNode();
 					handler(node);
+                    a.preventDefault();
+		            a.stopPropagation();
 				});
 			});
 		});


### PR DESCRIPTION
Key combination stroke (like ctrl+d, ctrl+s) will trigger browser's default behavior which is expected to be prevented and not for else because the event was already handled by fancytree's hotkey plugin.

Master: 

    $(tree.$container).on(event, null, key, function() {
        var node = tree.getActiveNode();
        handler(node);
    });

To be: 

    $(tree.$container).on(event, null, key, function(a) {
        var node = tree.getActiveNode();
        handler(node);
        a.preventDefault();
        a.stopPropagation();
    });
